### PR TITLE
feat: introduce readiness check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,18 @@ export default function app(): FastifyInstance {
     res.send(stringifyHealthCheck({ status: 'ok' }));
   });
 
+  app.get('/ready', (req, res) => {
+    const isBusy = pptrPool.available === 0;
+    res.type('application/health+json');
+    if (isBusy) {
+      res
+        .status(503)
+        .send(stringifyHealthCheck({ status: 'no available resources' }));
+    } else {
+      res.send(stringifyHealthCheck({ status: 'ok' }));
+    }
+  });
+
   // if (process.env.NODE_ENV !== 'test') {
   //   app.register(rateLimit, {
   //     max: 5,


### PR DESCRIPTION
The readiness endpoint checks whether there's an available puppeteer instance in the pool. If not it returns 503 so the load balancer will not forward traffic to this instance anymore.