### PR TITLE
docs: sync node version with .nvmrc to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The scraper can find the icon, rss feed, name, and other relevant information fo
 
 ## Stack
 
-* Node v12.19.0 (a `.nvmrc` is presented for [nvm](https://github.com/nvm-sh/nvm) users).
+* Node v16.20.0 (a `.nvmrc` is presented for [nvm](https://github.com/nvm-sh/nvm) users).
 * NPM for managing dependencies.
 * Fastify as the web framework
 


### PR DESCRIPTION
@idoshamun I found the README.md file has the deprecated node.js version, I found the .nvmrc already updated. So, it's just the README.