### PR TITLE
fix: update medium attribute for reading upvote count

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ const scrapeMediumVoters = async (
       key.startsWith('Post:'),
     );
     const voters = postKeys
-      .map((key) => state[key].voterCount)
+      .map((key) => state[key].clapCount)
       .find((voters) => voters >= 0);
     if (voters >= 0) {
       return {


### PR DESCRIPTION
The attribute to get the upvote count of a medium article changed from voterCount to clapCount.
This resolves issue #587 