### PR TITLE
feat: add user agent

### DIFF
--- a/src/scrape/index.ts
+++ b/src/scrape/index.ts
@@ -13,6 +13,10 @@ export async function scrape<T>(
   waitUntil: PuppeteerLifeCycleEvent = 'load',
 ): Promise<T> {
   const page = await browser.newPage();
+  await page.setUserAgent(
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 dailydotdev',
+  );
+
   try {
     const res = await page.goto(url, {
       waitUntil,


### PR DESCRIPTION
While implementing AS-352 in https://github.com/dailydotdev/apps/pull/3170 I noticed some favicons do not resolve, after checking I realized it was due to user agent so I added generic Chrome one + `dailydotdev` string at the end. Example is https://api.daily.dev/icon?url=https://openai.com&size=48