### PR TITLE
chore: update memory hpa

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -52,7 +52,7 @@ deployApplicationSuite({
       httpGet: { path: '/ready', port: 'http' },
       initialDelaySeconds: 10,
     },
-    metric: { type: 'memory_cpu', cpu: 80 },
+    metric: { type: 'memory_cpu', cpu: 80, memory: 150 },
     ports: [{ containerPort: 3000, name: 'http' }],
     servicePorts: [{ targetPort: 3000, port: 80, name: 'http' }],
     createService: true,


### PR DESCRIPTION
Forgot that now that limit/requests are different, we need to set hpa metric to a bit more.
Set it to 150% of request, so it would be around 1152Mi usage