### PR TITLE
fix: recycle pooled browsers to bound scraper memory

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -52,6 +52,13 @@ deployApplicationSuite({
       httpGet: { path: '/ready', port: 'http' },
       initialDelaySeconds: 10,
     },
+    // Liveness must NOT use /ready: it returns 503 when all browsers are busy,
+    // so a healthy-but-saturated pod would be killed under load. /health always
+    // reports ok and only fails if the process is actually wedged.
+    livenessProbe: {
+      httpGet: { path: '/health', port: 'http' },
+      initialDelaySeconds: 10,
+    },
     metric: { type: 'memory_cpu', cpu: 150, memory: 150 },
     ports: [{ containerPort: 3000, name: 'http' }],
     servicePorts: [{ targetPort: 3000, port: 80, name: 'http' }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,9 +114,38 @@ const pptrPool = genericPool.createPool(
   },
 );
 
+// Chromium's RSS grows monotonically the longer a browser process lives, even
+// when every page is closed. Pooling long-lived browsers (min: 5, never evicted
+// below min) therefore leaks memory until the pod is OOMKilled. Recycle each
+// browser after a bounded number of uses so a fresh process replaces it before
+// it bloats.
+const maxBrowserUses = parseInt(process.env.BROWSER_MAX_USES ?? '50', 10);
+const browserUses = new WeakMap<puppeteer.Browser, number>();
+
 const acquireAndRelease = async <T>(
   callback: (browser: puppeteer.Browser) => Promise<T>,
-): Promise<T> => pptrPool.use(callback);
+): Promise<T> => {
+  const browser = await pptrPool.acquire();
+  try {
+    const result = await callback(browser);
+    const uses = (browserUses.get(browser) ?? 0) + 1;
+    if (uses >= maxBrowserUses) {
+      browserUses.delete(browser);
+      // Permanently remove this browser; the pool recreates one to keep `min`.
+      await pptrPool.destroy(browser).catch(() => undefined);
+    } else {
+      browserUses.set(browser, uses);
+      await pptrPool.release(browser);
+    }
+    return result;
+  } catch (err) {
+    // On failure the browser may be in a bad state — discard it (matches the
+    // previous pool.use() behavior) so a fresh process replaces it.
+    browserUses.delete(browser);
+    await pptrPool.destroy(browser).catch(() => undefined);
+    throw err;
+  }
+};
 
 export default function app(): FastifyInstance {
   const isProd = process.env.NODE_ENV === 'production';


### PR DESCRIPTION
## Problem

Production scraper was pinned at its **max of 20 replicas** — but on **memory, not load**. CPU sat at ~37% while the HPA's memory metric held at ~148% of the 896Mi request (target 150%), so it never scaled down.

Root cause: the Puppeteer pool pools **entire Chromium browser instances** with `min: 5`, and the idle eviction only trims back to `min`. Those baseline browsers live forever and **never get recycled**. A long-lived Chromium process's RSS grows monotonically even when every page is closed, so each pod climbed from ~870Mi (fresh) to ~1800Mi over a few days, then either:
- hit the 2Gi cgroup limit → **OOMKilled (exit 137)**, or
- hit the `--max-old-space-size=1843` cap → **V8 heap OOM (exit 1)**.

This is why #600 (closing pages in `/screenshot` + `/pdf`) didn't fix it — pages were already closed; the leak is in the persistent browser *processes*.

## Changes

1. **Recycle browsers after `BROWSER_MAX_USES` (default 50) uses** (`src/index.ts`). Replaces `pool.use()` with manual acquire + release/destroy: after N successful uses a browser is destroyed so the pool spawns a fresh process. Destroy-on-error behavior of the old `pool.use()` is preserved. Bounds Chromium RSS permanently.
2. **Point the liveness probe at `/health`** instead of `/ready` (`.infra/index.ts`). `/ready` returns 503 when all browsers are busy, so a healthy-but-saturated pod was being killed by the kubelet under load. `/health` always reports ok; readiness still uses `/ready`.

## Testing

- `npm run lint`, `npm run build`, and `npm test` (30 tests) all pass locally.
- `BROWSER_MAX_USES` is env-tunable so we can adjust aggressiveness in prod without a rebuild.

## Follow-up (not in this PR)

Once memory is flat, reconsider dropping memory as an HPA metric (or raising the request) — CPU at 37% should let us scale well below 20 pods.