### PR TITLE
chore: raise scraper memory request to match working set

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -23,7 +23,11 @@ const { serviceAccount } = createServiceAccountAndGrantRoles(
   isAdhocEnv
 );
 
-const memory = 896
+// Steady-state working set is ~900-1130Mi (a pod pools up to 15 Chromium
+// browsers under load), so a 896Mi request kept pods permanently >100% of
+// request and the memory HPA metric on edge. Request it at the real working set
+// so CPU becomes the primary scaling signal; limit stays 2Gi for headroom.
+const memory = 1280
 const maxMemory = 2048
 
 const namespace = isAdhocEnv ? 'local' : 'daily';


### PR DESCRIPTION
Follow-up to #634.

## Why
After the browser-recycle fix, prod memory is bounded but the per-pod steady-state working set is **~900–1130Mi** (a pod pools up to 15 Chromium browsers under load). The memory **request** was still `896Mi`, so:
- Pods ran permanently at >100% of request.
- The memory-based HPA metric sat near 100–110% at min replicas, keeping it sensitive to transient memory-driven scale-ups (observed a brief 3→6 blip during babysitting that was really just load).

## Change
Raise the memory **request** `896 → 1280Mi` (`.infra/index.ts`). Limit unchanged at 2Gi.

Effect: utilization sits at a healthier ~75–90% of request, and **CPU becomes the primary scaling signal** — which actually reflects this workload (CPU ran ~20–40% while memory pinned scaling pre-fix).

## Validation
- `tsc --noEmit` on `.infra` passes.
- Pulumi preview will show only the request change; no app/image change.
- After deploy I'll confirm HPA memory % drops to the ~75–90% band and replicas stay at min under normal load.